### PR TITLE
Fixed npm install command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Install generator-ngbp from npm, run:
 
 ```
-$ npm install -g generator-ngbp-angular
+$ npm install -g generator-ngbp
 ```
 
 Create a new directory for your project and cd into it:


### PR DESCRIPTION
The npm install command was: npm install -g generator-ngbp-angular. That is incorrect though. The correct one is npm install generator-ngbp.
